### PR TITLE
chore: bump cask to 1.21.0

### DIFF
--- a/Casks/thock.rb
+++ b/Casks/thock.rb
@@ -1,6 +1,6 @@
 cask "thock" do
-  version "1.20.1"
-  sha256 "23e1c4e56a4d4d7286adc35081e7571d9e2aac966b0fb26de45fc529172bb790"
+  version "1.21.0"
+  sha256 "8d133fc6893b8a5ba3a337383c67a22dac560f7ab6e64344f09aaf7bc2866f7a"
 
   url "https://github.com/kamillobinski/thock/releases/download/#{version}/Thock-#{version}.zip"
   name "Thock"


### PR DESCRIPTION
Automated Thock cask version bump.