### PR TITLE
fix: trust the app after installing

### DIFF
--- a/Casks/thock.rb
+++ b/Casks/thock.rb
@@ -16,4 +16,10 @@ cask "thock" do
     Launch: open -a Thock
     CLI: thock-cli
   EOS
+  
+  postflight do
+    system_command "xattr",
+      args: ["-cr", "#{appdir}/Thock.app"],
+      sudo: false
+  end
 end


### PR DESCRIPTION
Trusts the app after installing via homebrew.

Needed so that users don't have to go into settings and manually trust the application.